### PR TITLE
Update PageTitleExtension.php to remove deprecatd message in symfony 5.4

### DIFF
--- a/src/Twig/Extension/PageTitleExtension.php
+++ b/src/Twig/Extension/PageTitleExtension.php
@@ -26,6 +26,9 @@ final class PageTitleExtension extends AbstractExtension implements PageTitleExt
         $this->pageHelper = $pageHelper;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getFunctions(): array
     {
         return [

--- a/src/Twig/Extension/PageTitleExtension.php
+++ b/src/Twig/Extension/PageTitleExtension.php
@@ -28,6 +28,7 @@ final class PageTitleExtension extends AbstractExtension implements PageTitleExt
 
     /**
      * @inheritDoc
+     * @return array
      */
     public function getFunctions(): array
     {

--- a/src/Twig/Extension/PageTitleExtension.php
+++ b/src/Twig/Extension/PageTitleExtension.php
@@ -27,7 +27,7 @@ final class PageTitleExtension extends AbstractExtension implements PageTitleExt
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      */
     public function getFunctions(): array
     {


### PR DESCRIPTION
Upgrading to symfony 5.4, this removes this depreciation message:

```
Method "Twig\Extension\ExtensionInterface::getFunctions()" might add "array" as a native return type declaration in the future. Do the same in implementation "Mobizel\Bundle\MarkdownDocsBundle\Twig\Extension\PageTitleExtension" now to avoid errors or add an explicit @return annotation to suppress this message.
```
